### PR TITLE
Improve layout templating and styling

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,8 @@
+title: Liam Keegan
+description: Personal website for Liam Keegan.
+url: "https://keegan.ch"
+baseurl: ""
+
 exclude:
   - README.md
   - LICENSE

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,12 @@
+- title: About me
+  url: /index.html
+- title: Projects
+  url: /projects.html
+- title: Teaching
+  url: /teaching.html
+- title: Open source
+  url: /open-source.html
+- title: Physics
+  url: /physics.html
+- title: CV
+  url: /cv.html

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,21 +1,7 @@
 ---
-navbar_pages:
-  - title: About me
-    url: index
-  - title: Projects
-    url: projects
-  - title: Teaching
-    url: teaching
-  - title: Open source
-    url: open-source
-  - title: Physics
-    url: physics
-  - title: CV
-    url: cv
 ---
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!doctype html>
+<html lang="en">
   <head>
     <meta name="author" content="Liam Keegan" />
     <meta charset="utf-8" />
@@ -24,11 +10,15 @@ navbar_pages:
       name="viewport"
       content="width=device-width, initial-scale=1"
     />
-    <title>Liam Keegan :: {{ page.title }}</title>
-    <link rel="shortcut icon" type="image/png" href="/imgs/favicon.png" />
+    <title>{{ site.title }} :: {{ page.title }}</title>
+    <link
+      rel="shortcut icon"
+      type="image/png"
+      href="{{ '/imgs/favicon.png' | relative_url }}"
+    />
     <link
       rel="stylesheet"
-      href="css/layout.css"
+      href="{{ '/css/layout.css' | relative_url }}"
       type="text/css"
       media="screen"
     />
@@ -44,21 +34,26 @@ navbar_pages:
         </div>
         <div id="navbar" class="navigation-buttons">
           <ul>
-            {% for navbar_page in layout.navbar_pages %}
+            {% for navbar_page in site.data.navigation %}
             <li>
               {% if navbar_page.title == page.title %}
-              <a class="active" href="{{ navbar_page.url }}.html"
+              <a class="active" href="{{ navbar_page.url | relative_url }}"
                 >{{ navbar_page.title }}</a
               >
               {% else %}
-              <a href="{{ navbar_page.url }}.html">{{ navbar_page.title}}</a>
+              <a href="{{ navbar_page.url | relative_url }}"
+                >{{ navbar_page.title }}</a
+              >
               {% endif %}
             </li>
             {% endfor %}
           </ul>
         </div>
       </div>
-      <div id="content" style="background-image:url(imgs/{{ page.image }});">
+      <div
+        id="content"
+        style="--page-bg-image: url('{{ page.image | prepend: '/imgs/' | relative_url }}');"
+      >
         <div id="pic"></div>
         <div id="txt">{{ content }}</div>
       </div>
@@ -66,22 +61,34 @@ navbar_pages:
         <ul>
           <li>
             <a href="https://orcid.org/0000-0002-0654-4979"
-              ><img src="imgs/ORCID.png" alt="ORCID" width="14px"
+              ><img
+                src="{{ '/imgs/ORCID.png' | relative_url }}"
+                alt="ORCID"
+                width="14px"
             /></a>
           </li>
           <li>
             <a href="https://www.xing.com/profile/Liam_Keegan2"
-              ><img src="imgs/XING.png" alt="XING" width="14px"
+              ><img
+                src="{{ '/imgs/XING.png' | relative_url }}"
+                alt="XING"
+                width="14px"
             /></a>
           </li>
           <li>
             <a href="https://www.linkedin.com/in/liamrgkeegan"
-              ><img src="imgs/LinkedIn.png" alt="LinkedIn" width="14px"
+              ><img
+                src="{{ '/imgs/LinkedIn.png' | relative_url }}"
+                alt="LinkedIn"
+                width="14px"
             /></a>
           </li>
           <li>
             <a href="https://github.com/lkeegan"
-              ><img src="imgs/GitHub.png" alt="GitHub" width="14px"
+              ><img
+                src="{{ '/imgs/GitHub.png' | relative_url }}"
+                alt="GitHub"
+                width="14px"
             /></a>
           </li>
           <li>

--- a/css/layout.css
+++ b/css/layout.css
@@ -78,18 +78,19 @@ a:visited {
 }
 
 .navigation-buttons ul {
+  display: flex;
+  flex-wrap: wrap;
   margin: 0;
   padding: 0;
 }
 
 .navigation-buttons ul li {
   list-style-type: none;
-  display: inline;
+  display: flex;
 }
 
 .navigation-buttons li a {
   display: block;
-  float: left;
   padding: 0.2em 0.6em;
   border-radius: 3px 3px 0 0;
   background: rgba(34, 51, 68, 0.5);
@@ -130,6 +131,7 @@ a:visited {
   background-repeat: no-repeat;
   background-size: 250px auto;
   background-position: 2em 3em;
+  background-image: var(--page-bg-image);
 }
 
 @media screen and (min-width: 768px) {
@@ -210,7 +212,7 @@ a:visited {
 }
 
 #content li li {
-  background-color: none;
+  background-color: transparent;
   list-style-type: square;
   margin: 0.5em 0;
   padding: 0;
@@ -246,8 +248,11 @@ a:visited {
   color: var(--text-title-color);
 }
 
+#footer ul {
+  justify-content: flex-end;
+}
+
 #footer ul li a {
-  float: right;
   border-width: 0 0 1px 1px;
   border-radius: 0 0 3px 3px !important;
 }


### PR DESCRIPTION
### Motivation
- Modernize the site's layout template and centralize navigation so links and paths resolve correctly when served by Jekyll.
- Make asset URLs and page metadata configurable via the site config to support different deploy bases and nicer page titles.
- Improve responsive layout and remove old float-based styling in favor of flexbox for more robust navigation and footer behavior.

### Description
- Added `_data/navigation.yml` and migrated the inline navbar list into a data-driven navigation model used by the layout.
- Updated `_layouts/default.html` to use HTML5 doc type, `site.title` for page titles, `relative_url` helpers for asset and page links, and a CSS variable for page background images.
- Added site metadata to `_config.yml` (`title`, `description`, `url`, `baseurl`).
- Revised `css/layout.css` to use flexbox for navigation and footer, replaced invalid background usages with a `--page-bg-image` variable, and fixed `background-color`/float usage for improved responsiveness.

### Testing
- Ran `jekyll serve --host 0.0.0.0 --port 4000`, which built the site successfully (`Generating... done`) and started the dev server without build errors.
- Attempted a Playwright screenshot of `http://127.0.0.1:4000/index.html`, but the headless Chromium process crashed and the screenshot run failed with a `TargetClosedError` (SIGSEGV) in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978b9142c84832ba435306fb5152e1f)